### PR TITLE
Expand relative paths before passing them to find

### DIFF
--- a/lib/holepicker/scanner.rb
+++ b/lib/holepicker/scanner.rb
@@ -71,6 +71,7 @@ module HolePicker
     end
 
     def scan_path(path)
+      path = File.expand_path(path)
       gemfiles = @roots ? find_gemfiles_in_configs(path) : find_gemfiles_in_path(path)
       gemfiles.each { |f| scan_gemfile(f) }
     end


### PR DESCRIPTION
Now `holepicker .` works as expected. Before, `find` would prune it (since it starts with a `.`) and nothing would get checked.
