### PR TITLE
Correct undefined method error

### DIFF
--- a/lib/holepicker/scanner.rb
+++ b/lib/holepicker/scanner.rb
@@ -108,8 +108,8 @@ module HolePicker
       if @matched_gemfiles == 0
         puts "No vulnerabilities found."
       else
-        puts ("#{@matched_gems} vulnerable #{Utils.pluralize(@matched_gems, 'gem')} found in " +
-          "#{@matched_gemfiles} #{Utils.pluralize(@matched_gemfiles, 'gemfile')}!").color(:red) + "\n\n"
+        puts(("#{@matched_gems} vulnerable #{Utils.pluralize(@matched_gems, 'gem')} found in " +
+          "#{@matched_gemfiles} #{Utils.pluralize(@matched_gemfiles, 'gemfile')}!").color(:red) + "\n\n")
 
         @found_vulnerabilities.sort_by(&:id).each do |v|
           puts "[#{v.tag}] #{v.day}: #{v.url}"


### PR DESCRIPTION
Currently if there are vulnerabilities found, an undefined method exception is raised in Scanner#print_report, because .color is called on the return value of puts (which is nul).  Patch adds extra parentheses to fix the error,
