### PR TITLE
Add option to warn only during deployment

### DIFF
--- a/lib/holepicker/capistrano.rb
+++ b/lib/holepicker/capistrano.rb
@@ -3,6 +3,7 @@ require 'holepicker/scanner'
 Capistrano::Configuration.instance.load do
   set(:holepicker_offline, false) unless exists?(:holepicker_offline)
   set(:holepicker_ignored_gems, []) unless exists?(:holepicker_ignored_gems)
+  set(:holepicker_warn_only, false) unless exists?(:holepicker_warn_only)
 
   before "deploy:update_code", "holepicker"
 
@@ -17,7 +18,11 @@ Capistrano::Configuration.instance.load do
       gemfile_lock = "#{ENV['BUNDLE_GEMFILE']}.lock"
       success = HolePicker::Scanner.new(gemfile_lock, options).scan
       unless success
-        raise Capistrano::CommandError.new("HolePicker found vulnerabilities!")
+        if holepicker_warn_only
+          logger.important "HolePicker found vulnerabilities!"
+        else
+          raise Capistrano::CommandError.new("HolePicker found vulnerabilities!")
+        end
       end
     end
   end


### PR DESCRIPTION
Hi,

I added an option to warn only instead of preventing the deployment when deploying an app with vulnerable gem. 

The default behaviour is still the same, but I needed to be able to only trigger a warning for some of the projects I work on, and I thought it might be useful for people other than me, so here it is!
