### PR TITLE
fix: new domain for github raw data + follow redirect to avoid further issues

### DIFF
--- a/lib/holepicker/online_database.rb
+++ b/lib/holepicker/online_database.rb
@@ -1,14 +1,13 @@
 require 'holepicker/database'
 require 'holepicker/logger'
 require 'holepicker/utils'
-require 'net/http'
-require 'net/https'
+require 'open-uri'
 
 module HolePicker
   class OnlineDatabase < Database
     include HasLogger
 
-    URL = 'https://raw.github.com/jsuder/holepicker/master/lib/holepicker/data/data.json'
+    URL = 'https://raw.githubusercontent.com/jsuder/holepicker/master/lib/holepicker/data/data.json'
 
     def self.load
       logger.info "Fetching list of vulnerabilities..."
@@ -32,12 +31,7 @@ module HolePicker
     private
 
     def self.http_get(url)
-      uri = URI(url)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = url.start_with?('https')
-
-      response = http.get(uri.request_uri)
-      response.body
+      open(url).read
     end
 
     def check_compatibility


### PR DESCRIPTION
Since last saturday, holepicker checks systematically fail to download the vulnerability JSON file.
This is because the domain used to host raw github files changed from raw.github.com to raw.githubuserdata.com, with a permanent redirect.

In order to avoid this problem, I made the two following changes.
- First, I made sure that the online database URL was the new one.
- Second, to avoid this problem if the domain changes again, I changed the library used by the http_get method from Net::HTTP to OpenUri, which automatically follows redirects.
